### PR TITLE
[UPDATE] Put new link to API docs

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -66,7 +66,7 @@ export function Hero() {
               </p>
               <div className="mt-8 flex gap-4 md:justify-center lg:justify-start">
                 <Button href="/">Get started</Button>
-                <Button href="https://cirroapiv2.docs.apiary.io/" variant="secondary">
+                <Button href="https://api-docs.cirro.io/" variant="secondary">
                   API Reference
                 </Button>
                 <Button href="https://developers.cirro.io/" variant="secondary">

--- a/src/data/main.js
+++ b/src/data/main.js
@@ -8,7 +8,7 @@ const main = [
   },
   {
     title: "API Reference",
-    href: "https://cirroapiv2.docs.apiary.io/",
+    href: "https://api-docs.cirro.io/",
     icon: CodeBracketIcon,
   },
   {


### PR DESCRIPTION
No longer need to display the link to apiary and replace it by our better version