### PR TITLE
update actions artifact to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Static HTML export with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next export
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./out
 


### PR DESCRIPTION
The github actions artifact we use is deprecated and blocks the deploy of main branch
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

https://github.com/test-IO/cirro-guides/actions/runs/17091218377/job/48465226477