### PR TITLE
hide VisuallyHiddenForAccessibility content, but make it available for screen readers

### DIFF
--- a/src/styles/docsearch.css
+++ b/src/styles/docsearch.css
@@ -180,6 +180,18 @@
   display: none;
 }
 
+.DocSearch-MagnifierLabel .DocSearch-VisuallyHiddenForAccessibility {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .DocSearch-Dropdown {
   height: 100%;
   max-height: calc(


### PR DESCRIPTION
fix this ugly text that is supposed to be hidden normally, but visible for screen readers

https://github.com/user-attachments/assets/670d25b6-3491-48d3-8d59-be6475c18027

